### PR TITLE
Add optparse explicitly, update clear_load_cache call

### DIFF
--- a/lib/rubygems/commands/server_command.rb
+++ b/lib/rubygems/commands/server_command.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'rubygems/command'
+require 'optparse'
 require_relative '../server'
 
 class Gem::Commands::ServerCommand < Gem::Command

--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -489,7 +489,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
     latest_specs = Gem::Specification.latest_specs
 
     specs = latest_specs.sort.map do |spec|
-      platform = spec.original_platform || Gem::Platform::RUBY
+      platform = spec.platform || Gem::Platform::RUBY
       [spec.name, spec.version, platform]
     end
 
@@ -550,7 +550,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
     specs = Gem::Specification.select do |spec|
       spec.version.prerelease?
     end.sort.map do |spec|
-      platform = spec.original_platform || Gem::Platform::RUBY
+      platform = spec.platform || Gem::Platform::RUBY
       [spec.name, spec.version, platform]
     end
 
@@ -849,7 +849,7 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
     add_date res
 
     specs = Gem::Specification.sort_by(&:sort_obj).map do |spec|
-      platform = spec.original_platform || Gem::Platform::RUBY
+      platform = spec.platform || Gem::Platform::RUBY
       [spec.name, spec.version, platform]
     end
 

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -961,7 +961,7 @@ Also, a list:
       s.files = %w[lib/code.rb]
       s.require_paths = %w[lib]
       s.platform = Gem::Platform.new 'i386-linux'
-      s.instance_variable_set :@original_platform, 'i386-linux'
+      s.instance_variable_set :@platform, 'i386-linux'
     end
 
     if prerelease

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -463,7 +463,7 @@ class Gem::TestCase < Test::Unit::TestCase
       Gem.instance_variable_set :@default_dir, nil
     end
 
-    Gem::Specification.send(:clear_load_cache)
+    Gem::Specification.reset
     Gem::Specification.unresolved_deps.clear
     Gem::refresh
 

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -463,7 +463,7 @@ class Gem::TestCase < Test::Unit::TestCase
       Gem.instance_variable_set :@default_dir, nil
     end
 
-    Gem::Specification._clear_load_cache
+    Gem::Specification.send(:clear_load_cache)
     Gem::Specification.unresolved_deps.clear
     Gem::refresh
 

--- a/test/rubygems/test_gem_commands_server_command.rb
+++ b/test/rubygems/test_gem_commands_server_command.rb
@@ -48,14 +48,13 @@ class TestGemCommandsServerCommand < Gem::TestCase
       @cmd.send :handle_options, %w[-p nonexistent]
     end
 
-    assert_equal 'invalid argument: -p nonexistent: no such named service',
-                 e.message
+    assert_equal 'invalid argument: nonexistent: no such named service', e.message
 
     e = assert_raise OptionParser::InvalidArgument do
       @cmd.send :handle_options, %w[-p 65536]
     end
 
-    assert_equal 'invalid argument: -p 65536: not a port number',
+    assert_equal 'invalid argument: 65536: not a port number',
                  e.message
   end
 end

--- a/test/rubygems/utilities.rb
+++ b/test/rubygems/utilities.rb
@@ -290,7 +290,7 @@ class Gem::TestCase::SpecFetcherSetup
   def legacy_platform
     spec 'pl', 1 do |s|
       s.platform = Gem::Platform.new 'i386-linux'
-      s.instance_variable_set :@original_platform, 'i386-linux'
+      s.instance_variable_set :@platform, 'i386-linux'
     end
   end
 


### PR DESCRIPTION
Looks like optparse needs to be loaded explicitly.

Addresses https://github.com/rubygems/rubygems-server/issues/1

While I was here I noticed that `rake test` failed with an undefined method for `_clear_load_cache`. Seems like that was removed at some point several years ago and I suspect it was just a cheeky way to call a method that was private. I've updated it to call the private method explicitly using `send`.