### PR TITLE
Fix some issues in rubygems 3.3.9

### DIFF
--- a/lib/rubygems/commands/server_command.rb
+++ b/lib/rubygems/commands/server_command.rb
@@ -8,10 +8,10 @@ class Gem::Commands::ServerCommand < Gem::Command
     super 'server', 'Documentation and gem repository HTTP server',
           :port => 8808, :gemdir => [], :daemon => false
 
-    OptionParser.accept :Port do |port|
+    Gem::OptionParser.accept :Port do |port|
       if port =~ /\A\d+\z/
         port = Integer port
-        raise OptionParser::InvalidArgument, "#{port}: not a port number" if
+        raise Gem::OptionParser::InvalidArgument, "#{port}: not a port number" if
           port > 65535
 
         port
@@ -19,7 +19,7 @@ class Gem::Commands::ServerCommand < Gem::Command
         begin
           Socket.getservbyname port
         rescue SocketError
-          raise OptionParser::InvalidArgument, "#{port}: no such named service"
+          raise Gem::OptionParser::InvalidArgument, "#{port}: no such named service"
         end
       end
     end

--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -488,10 +488,9 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
 
     latest_specs = Gem::Specification.latest_specs
 
-    specs = latest_specs.sort.map do |spec|
-      platform = spec.original_platform || Gem::Platform::RUBY
-      [spec.name, spec.version, platform]
-    end
+    specs = latest_specs.map do |spec|
+      [spec.name, spec.version, spec.platform]
+    end.sort
 
     specs = Marshal.dump specs
 

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -463,8 +463,8 @@ class Gem::TestCase < Test::Unit::TestCase
       Gem.instance_variable_set :@default_dir, nil
     end
 
-    Gem::Specification._clear_load_cache
     Gem::Specification.unresolved_deps.clear
+    Gem::Specification.reset
     Gem::refresh
 
     @orig_hooks.each do |name, hooks|

--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -284,6 +284,13 @@ class Gem::TestCase < Test::Unit::TestCase
     }, msg
   end
 
+  def assert_contains_specs(expected, specs)
+    expected = expected.sort
+    keys = expected.map {|item| item[0]}.uniq
+    specs = specs.select {|item| keys.include?(item[0])}.sort
+    assert_equal expected, specs
+  end
+
   include Gem::DefaultUserInteraction
 
   ##

--- a/test/rubygems/test_gem_commands_server_command.rb
+++ b/test/rubygems/test_gem_commands_server_command.rb
@@ -40,18 +40,18 @@ class TestGemCommandsServerCommand < Gem::TestCase
     begin
       @cmd.send :handle_options, %w[-p discard]
       assert_equal 9, @cmd.options[:port]
-    rescue OptionParser::InvalidArgument
+    rescue Gem::OptionParser::InvalidArgument
       # for container environment on GitHub Actions
     end
 
-    e = assert_raise OptionParser::InvalidArgument do
+    e = assert_raise Gem::OptionParser::InvalidArgument do
       @cmd.send :handle_options, %w[-p nonexistent]
     end
 
     assert_equal 'invalid argument: -p nonexistent: no such named service',
                  e.message
 
-    e = assert_raise OptionParser::InvalidArgument do
+    e = assert_raise Gem::OptionParser::InvalidArgument do
       @cmd.send :handle_options, %w[-p 65536]
     end
 

--- a/test/rubygems/test_gem_server.rb
+++ b/test/rubygems/test_gem_server.rb
@@ -87,7 +87,7 @@ class TestGemServer < Gem::TestCase
     assert_equal 200, @res.status, @res.body
     assert_match %r{ \d\d:\d\d:\d\d }, @res['date']
     assert_equal 'application/octet-stream', @res['content-type']
-    assert_equal [['a', Gem::Version.new(2), Gem::Platform::RUBY]],
+    assert_contains_specs [['a', Gem::Version.new(2), Gem::Platform::RUBY]],
     Marshal.load(@res.body)
   end
 
@@ -112,7 +112,7 @@ class TestGemServer < Gem::TestCase
 
     assert_equal 200, @res.status
 
-    assert_equal [['z', v(9), Gem::Platform::RUBY]], Marshal.load(@res.body)
+    assert_contains_specs [['z', v(9), Gem::Platform::RUBY]], Marshal.load(@res.body)
   end
 
   def test_latest_specs_gz
@@ -126,7 +126,7 @@ class TestGemServer < Gem::TestCase
     assert_equal 200, @res.status, @res.body
     assert_match %r{ \d\d:\d\d:\d\d }, @res['date']
     assert_equal 'application/x-gzip', @res['content-type']
-    assert_equal [['a', Gem::Version.new(2), Gem::Platform::RUBY]],
+    assert_contains_specs [['a', Gem::Version.new(2), Gem::Platform::RUBY]],
                  Marshal.load(Gem::Util.gunzip(@res.body))
   end
 
@@ -161,7 +161,7 @@ class TestGemServer < Gem::TestCase
     assert_equal 200, @res.status, @res.body
     assert_match %r{ \d\d:\d\d:\d\d }, @res['date']
     assert_equal 'application/octet-stream', @res['content-type']
-    assert_equal [['a', v('3.a'), Gem::Platform::RUBY]],
+    assert_contains_specs [['a', v('3.a'), Gem::Platform::RUBY]],
                  Marshal.load(@res.body)
   end
 
@@ -176,7 +176,7 @@ class TestGemServer < Gem::TestCase
     assert_equal 200, @res.status, @res.body
     assert_match %r{ \d\d:\d\d:\d\d }, @res['date']
     assert_equal 'application/x-gzip', @res['content-type']
-    assert_equal [['a', v('3.a'), Gem::Platform::RUBY]],
+    assert_contains_specs [['a', v('3.a'), Gem::Platform::RUBY]],
                  Marshal.load(Gem::Util.gunzip(@res.body))
   end
 
@@ -529,7 +529,7 @@ class TestGemServer < Gem::TestCase
     assert_match %r{ \d\d:\d\d:\d\d }, @res['date']
     assert_equal 'application/octet-stream', @res['content-type']
 
-    assert_equal [['a', Gem::Version.new(1), Gem::Platform::RUBY],
+    assert_contains_specs [['a', Gem::Version.new(1), Gem::Platform::RUBY],
                   ['a', Gem::Version.new(2), Gem::Platform::RUBY],
                   ['a', v('3.a'), Gem::Platform::RUBY]],
                  Marshal.load(@res.body)
@@ -556,7 +556,7 @@ class TestGemServer < Gem::TestCase
 
     assert_equal 200, @res.status
 
-    assert_equal [['z', v(9), Gem::Platform::RUBY]], Marshal.load(@res.body)
+    assert_contains_specs [['z', v(9), Gem::Platform::RUBY]], Marshal.load(@res.body)
   end
 
   def test_specs_gz
@@ -569,7 +569,7 @@ class TestGemServer < Gem::TestCase
     assert_match %r{ \d\d:\d\d:\d\d }, @res['date']
     assert_equal 'application/x-gzip', @res['content-type']
 
-    assert_equal [['a', Gem::Version.new(1), Gem::Platform::RUBY],
+    assert_contains_specs [['a', Gem::Version.new(1), Gem::Platform::RUBY],
                   ['a', Gem::Version.new(2), Gem::Platform::RUBY],
                   ['a', v('3.a'), Gem::Platform::RUBY]],
                  Marshal.load(Gem::Util.gunzip(@res.body))


### PR DESCRIPTION
I fixed rubygems-server 0.1.0 not working with rubygems 3.3.9.

**NOTE: This PR conflicts with #2.**