### PR TITLE
Cleanup tmp directory in teardown

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -452,6 +452,7 @@ class Gem::TestCase < Test::Unit::TestCase
     Dir.chdir @current_dir
 
     FileUtils.rm_rf @tempdir
+    FileUtils.rm_rf @tmp
 
     ENV.replace(@orig_env)
 


### PR DESCRIPTION
I noticed that after I run the tests there's a `tmp` directory that's still lingering around. This modifies the test helper so that it's cleaned up.