### PR TITLE
README.md: Usage: Add `require 'rubygems/server'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Or install it yourself as:
 ##  Usage
 
 ```ruby
+require 'rubygems/server'
+
 gem_server = Gem::Server.new Gem.dir, 8089, false
 gem_server.run
 ```


### PR DESCRIPTION
This PR is related to https://github.com/rubygems/rubygems-server/issues/12.

Add `require 'rubygems/server'` to run the example script in the usage section smoothly.

