### PR TITLE
Fix handling RDoc::Servlet rename to RDoc::RI::Servlet

### DIFF
--- a/lib/rubygems/server.rb
+++ b/lib/rubygems/server.rb
@@ -809,7 +809,8 @@ div.method-source-code pre { color: #ffdead; overflow: hidden; }
       '/gems' => '/cache/',
     }
 
-    @server.mount '/doc_root', RDoc::Servlet, '/doc_root'
+    servlet = defined?(RDoc::Servlet) ? RDoc::Servlet : RDoc::RI::Servlet
+    @server.mount '/doc_root', servlet, '/doc_root'
 
     @gem_dirs.each do |gem_dir|
       file_handlers.each do |mount_point, mount_dir|


### PR DESCRIPTION
This PR fixes #12.

I tested in the cases Ruby 4.1 dev with `RDoc::RI::Servlet` and Ruby 4.0 with `RDoc::Servlet`.

---

This commit fixes the following error in Ruby 4.1.0dev.

bin/gem_server.rb
```
require 'rubygems/server'

gem_server = Gem::Server.new Gem.dir, 8089, false
gem_server.run
```

```
$ ruby bin/gem_server.rb
Server started at http://0.0.0.0:8089
Server started at http://[::]:8089
/home/jaruga/.local/ruby-4.1.0-debug-7d4941d3e1-openssl-4.1.0-5e32b3e3fa/lib/ruby/gems/4.1.0+1/gems/rubygems-server-0.3.0/lib/rubygems/server.rb:825:in 'Gem::Server#run': uninitialized constant RDoc::Servlet (NameError)

      @server.mount '/doc_root', RDoc::Servlet, '/doc_root'
                                     ^^^^^^^^^
Did you mean?  RDoc::Server
	from bin/gem_server.rb:4:in '<main>'
```

Because ruby/rdoc renamed the `RDoc::Servlet` to `RDoc::RI::Servlet` at the following commit.

https://github.com/ruby/rdoc/commit/3c6f5f6fd253dfac7ac6af61e05692b05912089b